### PR TITLE
 made build script more resilient and added environment script

### DIFF
--- a/NCSA_Blue_Waters/build_hdf5-1.10.0.sh
+++ b/NCSA_Blue_Waters/build_hdf5-1.10.0.sh
@@ -65,7 +65,7 @@ cd build
 
 ../configure --prefix=${HDF5_INSTALL_DIR} --disable-silent-rules --enable-fortran --enable-fortran2003 --enable-static --with-pic --disable-sharedlib-rpath --with-zlib=/usr/lib64 --enable-parallel --enable-shared --enable-build-mode=production
 
-sed -i -e 's|wl=""|wl="-Wl,"|g' -e 's|pic_flag=" -.PIC"|pic_flag=" -hPIC"|g' libtool
+sed -i -e 's|wl=""|wl="-Wl,"|g' -e 's|pic_flag=" -.PIC"|pic_flag=" -hPIC"|g' `which libtool`
 
 make -j 8
 make install

--- a/NCSA_Blue_Waters/build_hdf5-1.10.0.sh
+++ b/NCSA_Blue_Waters/build_hdf5-1.10.0.sh
@@ -8,6 +8,10 @@
 # Build script to build hdf5 on Blue Waters
 
 
+# Q's: which 'automake' is used? Does it matter? Not part of pre-install stuff
+
+# PRE: Download and unpack pristine sources to $SOURCES_DIR
+
 ###################### Set values for these three environment variables:
 
 # where is the build instructions repo? 
@@ -20,21 +24,25 @@ export HDF5_INSTALL_DIR=$HOME/local/phdf5-1.10.0-install
 
 ###################### Should not need to make changes below here. 
 
+# build directory where package will be assembled
+export BUILD_DIR=$SOURCES_DIR/build
+mkdir -p $BUILD_DIR
+cd $BUILD_DIR
+# Need a newer version of autotools, so run pre-install script to install here
+. $BW_BUILD_INSTRUCTIONS_DIR/preinstall_hdf5.sh
+# add libtool to path
+export PATH=`pwd`/util/bin:$PATH
+cd $SOURCES_DIR 
 
-# Need a newer version of autotools, so run pre-install script:
-cd $BW_BUILD_INSTRUCTIONS_DIR
-. preinstall_hdf5.sh
-export PATH=$BW_BUILD_INSTRUCTIONS_DIR/util/bin:$PATH
-
-
-# comment out the following because it's not recognized and hangs configure
+# the following line will comment out AM_SILENT_RULES in the resulting 
+# configure script, because it's not recognized and hangs autogen
 sed -i -e "s/AM_SILENT_RULES/## AM_SILENT_RULES/" $SOURCES_DIR/configure.ac
 
 
 # Get the modules in order so we have the right environment vars set:
 source /opt/modules/default/init/bash
 module swap cce cce/8.3.14
-module unload cray-libsci atp
+module unload cray-libsci atp darshan
 module load xpmem dmapp ugni udreg
 module swap cray-mpich cray-mpich/7.2.4
 
@@ -54,18 +62,30 @@ export CFLAGS="-DCRAYCC -dynamic"
 export LDFLAGS="-Wl,--no-as-needed,-lm,-lrt,--as-needed"
 export FCFLAGS="-em -dynamic"
 export CXXFLAGS="-DpgiFortran"
+
+# This messes up the build, which needs to run a script to generate H5lib_settings.c
+# Because build runs on the head node.
+# export RUNSERIAL="aprun -q -n 1"
 export RUNPARALLEL="aprun -n 6"
 
 
 # Okay, go do it
-cd $SOURCES_DIR
 ./autogen.sh
-mkdir build
-cd build
+cd $BUILD_DIR
 
-../configure --prefix=${HDF5_INSTALL_DIR} --disable-silent-rules --enable-fortran --enable-fortran2003 --enable-static --with-pic --disable-sharedlib-rpath --with-zlib=/usr/lib64 --enable-parallel --enable-shared --enable-build-mode=production
+../configure --prefix=${HDF5_INSTALL_DIR} --enable-parallel --enable-build-mode=production \
+             --enable-fortran --enable-static --enable-shared --with-pic \
+             --disable-sharedlib-rpath --with-zlib=/usr/lib64 --disable-silent-rules 
 
-sed -i -e 's|wl=""|wl="-Wl,"|g' -e 's|pic_flag=" -.PIC"|pic_flag=" -hPIC"|g' `which libtool`
+#sed -i -e 's|wl=""|wl="-Wl,"|g' -e 's|pic_flag=" -.PIC"|pic_flag=" -hPIC"|g' `which libtool`
+sed -i -e 's|wl=""|wl="-Wl,"|g' -e 's|pic_flag=" -.PIC"|pic_flag=" -hPIC"|g' libtool
 
 make -j 8
 make install
+export LD_LIBRARY_PATH=$SRC/build-hdf5/src/.libs:$LD_LIBRARY_PATH
+
+echo "Done installing to ${HDF5_INSTALL_DIR}. Do remember to run the environment script when building."
+
+
+
+

--- a/NCSA_Blue_Waters/build_install_feature.sh
+++ b/NCSA_Blue_Waters/build_install_feature.sh
@@ -1,13 +1,21 @@
 /bin/bash
 
 # Source this script to build and install a feature branch on BW.
+# Set these environment vars appropriately or before sourcing script; the rest should just work
 
-# Set these environment vars appropriately, the rest should just work
+if [ $SOURCES_DIR"x" == "x" ]; then 
+    export SOURCES_DIR=/u/sciteam/willmore/local/hdf5-1.9.236
+fi
 
-export SOURCES_DIR=/u/sciteam/willmore/local/hdf5-1.9.236
-export HDF5_INSTALL_DIR=/sw/bw/thg/phdf5/1.9.236
+if [ $HDF5_INSTALL_DIR"x" == "x" ]; then 
+    export HDF5_INSTALL_DIR=/sw/bw/thg/phdf5/1.9.236
+fi
+
+##############################################################################
 
 # Should not need to edit below here.  
+
+##############################################################################
 
 module load autoconf/2.69
 module unload darshan

--- a/NCSA_Blue_Waters/build_install_feature.sh
+++ b/NCSA_Blue_Waters/build_install_feature.sh
@@ -5,7 +5,7 @@
 # Set these environment vars appropriately, the rest should just work
 
 export SOURCES_DIR=/u/sciteam/willmore/local/hdf5-1.9.236
-export HDF5_INSTALL_DIR=/sw/bw/thg/phdf5-1.9.236_ftw 
+export HDF5_INSTALL_DIR=/sw/bw/thg/phdf5/1.9.236
 
 # Should not need to edit below here.  
 

--- a/NCSA_Blue_Waters/build_install_feature.sh
+++ b/NCSA_Blue_Waters/build_install_feature.sh
@@ -9,7 +9,7 @@ export HDF5_INSTALL_DIR=/sw/bw/thg/phdf5-1.9.236_ftw
 
 # Should not need to edit below here.  
 
-module load autoconf/2.6.9
+module load autoconf/2.69
 module unload darshan
 
 # This macro breaks configure, so I just comment it out with this in-place edit:
@@ -34,5 +34,5 @@ make -j8 install
  
 #Load craypkg-gen to make the package and module:
 module load craypkg-gen
-craypkg-gen -p /sw/bw/thg/phdf5/1.9.236_ftw/
-craypkg-gen -m /sw/bw/thg/phdf5/1.9.236_ftw/ 
+craypkg-gen -p $HDF5_INSTALL_DIR
+craypkg-gen -m $HDF5_INSTALL_DIR

--- a/NCSA_Blue_Waters/build_install_feature.sh
+++ b/NCSA_Blue_Waters/build_install_feature.sh
@@ -1,0 +1,38 @@
+/bin/bash
+
+# Source this script to build and install a feature branch on BW.
+
+# Set these environment vars appropriately, the rest should just work
+
+export SOURCES_DIR=/u/sciteam/willmore/local/hdf5-1.9.236
+export HDF5_INSTALL_DIR=/sw/bw/thg/phdf5-1.9.236_ftw 
+
+# Should not need to edit below here.  
+
+module load autoconf/2.6.9
+module unload darshan
+
+# This macro breaks configure, so I just comment it out with this in-place edit:
+sed -i -e "s/AM_SILENT_RULES/## AM_SILENT_RULES/" $SOURCES_DIR/configure.ac
+# Set some environment stuff that the Cray compiler likes:
+export XTPE_LINK_TYPE=dynamic
+export RUNPARALLEL="aprun -n 6"
+export CXXFLAGS="-DpgiFortran"
+export FCFLAGS="-em -dynamic"
+export LDFLAGS="-Wl,--no-as-needed,-lm,-lrt,--as-needed"
+export CFLAGS="-DCRAYCC -dynamic"
+export CRAY_CPU_TARGET="x86-64" 
+export CXX="CC"
+export FC="ftn"
+export CC="cc"
+export LIBS="-L${CRAY_MPICH2_DIR}/lib -lmpichf90_cray -lmpich_cray"
+# Start the build process in earnest:
+./autogen.sh
+./configure --prefix=${HDF5_INSTALL_DIR} --enable-fortran --enable-static --with-pic --disable-sharedlib-rpath --with-zlib=/usr/lib64 --enable-parallel --enable-shared --enable-build-mode=production
+sed -i -e 's|wl=""|wl="-Wl,"|g' -e 's|pic_flag=" -.PIC"|pic_flag=" -hPIC"|g' libtool
+make -j8 install
+ 
+#Load craypkg-gen to make the package and module:
+module load craypkg-gen
+craypkg-gen -p /sw/bw/thg/phdf5/1.9.236_ftw/
+craypkg-gen -m /sw/bw/thg/phdf5/1.9.236_ftw/ 

--- a/NCSA_Blue_Waters/build_install_feature.sh
+++ b/NCSA_Blue_Waters/build_install_feature.sh
@@ -20,6 +20,8 @@ fi
 module load autoconf/2.69
 module unload darshan
 
+cd $SOURCES_DIR
+
 # This macro breaks configure, so I just comment it out with this in-place edit:
 sed -i -e "s/AM_SILENT_RULES/## AM_SILENT_RULES/" $SOURCES_DIR/configure.ac
 # Set some environment stuff that the Cray compiler likes:

--- a/NCSA_Blue_Waters/env_hdf5-1.10.0.sh
+++ b/NCSA_Blue_Waters/env_hdf5-1.10.0.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#   ___  __           _      __     __
+#  / _ )/ /_ _____   | | /| / /__ _/ /____ _______
+# / _  / / // / -_)  | |/ |/ / _ `/ __/ -_) __(_-<
+#/____/_/\_,_/\__/   |__/|__/\_,_/\__/\__/_/ /___/
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# set up correct build environment once the library is built
+
+# Get the modules in order so we have the right environment vars set:
+source /opt/modules/default/init/bash
+module swap cce cce/8.3.14
+module unload cray-libsci atp darshan
+module load xpmem dmapp ugni udreg
+module swap cray-mpich cray-mpich/7.2.4
+module list
+
+# this should be set according to your install
+export HDF5_INSTALL_DIR=${HOME}/local/phdf5-1.10.0-install
+
+# set up user env vars
+export PATH=${HDF5_INSTALL_DIR}/bin:$PATH 
+export LD_LIBRARY_PATH=${HDF5_INSTALL_DIR}/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${CRAY_MPICH2_DIR}/lib:$LD_LIBRARY_PATH
+export INCLUDE_PATH=${HDF5_INSTALL_DIR}/include:$INCLUDE_PATH 
+
+export XTPE_LINK_TYPE=dynamic
+export LIBS="-L${CRAY_MPICH2_DIR}/lib -lmpichf90_cray -lmpich_cray"
+
+export CC="cc"
+export FC="ftn"
+export CXX="CC"
+
+export CRAY_CPU_TARGET="x86-64" 
+
+export CFLAGS="-DCRAYCC -dynamic"
+export LDFLAGS="-Wl,--no-as-needed,-lm,-lrt,--as-needed"
+export FCFLAGS="-em -dynamic"
+export CXXFLAGS="-DpgiFortran"
+


### PR DESCRIPTION
The build script can be run from anywhere, and can be run as a separate shell or sourced in the same shell. 

The environment script is necessary to make sure the correct Cray modules are loaded, as well as setting up environment at application build time. This exists in lieu of a module. 
